### PR TITLE
Split quotas implemented for csv export

### DIFF
--- a/quotas/quotaGroup.js
+++ b/quotas/quotaGroup.js
@@ -118,15 +118,60 @@ class QuotaGroup {
         return alertMsg;
     }
 
-
     displayQuotas() {
         let grpData = "";
         for (let i = 0; i < this.subQuotas.length; i++) {
             grpData += this.subQuotas[i].display();
         }
+
+        let dummyGroup = new QuotaGroup ("", {
+            id: generateId(),
+            nSizes: [33,33,33],
+            isTri: false,
+            isDual: false,
+            isFlex: false,
+            isRawFlex: false,
+            flexAmount: false,
+            hasSplits: false,
+            splits: []
+        }, []);
+        QUOTA_GROUPS.forEach(group => { // Search for quota groups with splits
+            if (group.hasSplits) {
+                group.splits.forEach(splitName => { // For each split, match it with another group in QUOTA_GROUPS
+                    QUOTA_GROUPS.forEach(otherGroup => {
+                        if(otherGroup.group_name === splitName) { // When we find a match, start creating temporary quotas to add
+                            let fullN = group.totalN;
+                            let splitPercentages = [];
+                            otherGroup.nSizes.forEach(n => {
+                                splitPercentages.push(n/fullN);
+                            });
+                            group.subQuotas.forEach(mainQuota => {
+                                otherGroup.subQuotas.forEach(splitQuota => {
+                                    grpData += new Quota(
+                                        dummyGroup,
+                                        mainQuota.name + " / " + splitQuota.name,
+                                        ((mainQuota.isRaw ? mainQuota.valLimit / fullN : mainQuota.valLimit) * (splitQuota.isRaw ? splitQuota.valLimit / fullN : splitQuota.valLimit) * fullN).toString(),
+                                        mainQuota.qName,
+                                        mainQuota.qCodes,
+                                        mainQuota.client
+                                    ).display();
+                                    grpData += new Quota(
+                                        dummyGroup,
+                                        mainQuota.name + " / " + splitQuota.name,
+                                        ((mainQuota.isRaw ? mainQuota.valLimit / fullN : mainQuota.valLimit) * (splitQuota.isRaw ? splitQuota.valLimit / fullN : splitQuota.valLimit) * fullN).toString(),
+                                        splitQuota.qName,
+                                        splitQuota.qCodes,
+                                        splitQuota.client
+                                    ).display();
+                                });
+                            });
+                        }
+                    });
+                });
+            }
+        });
+
         return grpData;
     }
-
-
 
 }

--- a/quotas/quotaGroup.js
+++ b/quotas/quotaGroup.js
@@ -123,54 +123,6 @@ class QuotaGroup {
         for (let i = 0; i < this.subQuotas.length; i++) {
             grpData += this.subQuotas[i].display();
         }
-
-        let dummyGroup = new QuotaGroup ("", {
-            id: generateId(),
-            nSizes: [33,33,33],
-            isTri: false,
-            isDual: false,
-            isFlex: false,
-            isRawFlex: false,
-            flexAmount: false,
-            hasSplits: false,
-            splits: []
-        }, []);
-        QUOTA_GROUPS.forEach(group => { // Search for quota groups with splits
-            if (group.hasSplits) {
-                group.splits.forEach(splitName => { // For each split, match it with another group in QUOTA_GROUPS
-                    QUOTA_GROUPS.forEach(otherGroup => {
-                        if(otherGroup.group_name === splitName) { // When we find a match, start creating temporary quotas to add
-                            let fullN = group.totalN;
-                            let splitPercentages = [];
-                            otherGroup.nSizes.forEach(n => {
-                                splitPercentages.push(n/fullN);
-                            });
-                            group.subQuotas.forEach(mainQuota => {
-                                otherGroup.subQuotas.forEach(splitQuota => {
-                                    grpData += new Quota(
-                                        dummyGroup,
-                                        mainQuota.name + " / " + splitQuota.name,
-                                        ((mainQuota.isRaw ? mainQuota.valLimit / fullN : mainQuota.valLimit) * (splitQuota.isRaw ? splitQuota.valLimit / fullN : splitQuota.valLimit) * fullN).toString(),
-                                        mainQuota.qName,
-                                        mainQuota.qCodes,
-                                        mainQuota.client
-                                    ).display();
-                                    grpData += new Quota(
-                                        dummyGroup,
-                                        mainQuota.name + " / " + splitQuota.name,
-                                        ((mainQuota.isRaw ? mainQuota.valLimit / fullN : mainQuota.valLimit) * (splitQuota.isRaw ? splitQuota.valLimit / fullN : splitQuota.valLimit) * fullN).toString(),
-                                        splitQuota.qName,
-                                        splitQuota.qCodes,
-                                        splitQuota.client
-                                    ).display();
-                                });
-                            });
-                        }
-                    });
-                });
-            }
-        });
-
         return grpData;
     }
 

--- a/quotas/quota_parse.js
+++ b/quotas/quota_parse.js
@@ -226,3 +226,19 @@ function generateId() {
     }
     return newId;
 }
+
+function generateSplits() {
+    
+}
+
+function generateCSVLine(qName, qType, qCode, aCode, limit, active) {
+    let rowStr = "";
+    let suffix = '"{""action"":""1"",""autoload_url"":""1"",""active"":""' + (active ? "1" : "0") +
+                    '"",""qls"":[{""quotals_language"":""en"",""quotals_name"":""x"",""quotals_url"":"""",' +
+                    '""quotals_urldescrip"":"""",""quotals_message"":""Sorry your responses have exceeded' +
+                    ' a quota on this survey.""}]}"';
+
+    rowStr += qName + "," + qType + "," + qCode + "," + aCode + "," + limit + "," + suffix + "\n";
+
+    return rowStr;
+}


### PR DESCRIPTION
The name separation could use some work, but it's functional as of now. I'm thinking we should rename qName and qCodes to qCode and ansCode or something like that so we're more consistent with LS terms.